### PR TITLE
feat: Implement thread-based display for search results

### DIFF
--- a/src/thesisherald/bot.py
+++ b/src/thesisherald/bot.py
@@ -93,7 +93,7 @@ class ThesisHeraldBot(commands.Bot):
         # Send each paper to the thread
         for i, paper in enumerate(papers, 1):
             try:
-                message = f"**[{i}/{len(papers)}]**\n{paper.format_discord_message()}"
+                message = f"**[{i}/{len(papers)}]**\n{paper.format_discord_message()}\n{'-' * 50}"
                 await thread.send(message)
             except discord.HTTPException as e:
                 logger.error(f"Failed to send paper {paper.arxiv_id}: {e}")
@@ -158,7 +158,7 @@ def create_bot(config: Config) -> ThesisHeraldBot:
 
             # Send all papers in the thread
             for i, paper in enumerate(papers, 1):
-                message = f"**[{i}/{len(papers)}]**\n{paper.format_discord_message()}"
+                message = f"**[{i}/{len(papers)}]**\n{paper.format_discord_message()}\n{'-' * 50}"
                 await thread.send(message)
 
         except Exception as e:
@@ -225,7 +225,7 @@ def create_bot(config: Config) -> ThesisHeraldBot:
 
             # Send all papers in the thread
             for i, paper in enumerate(papers, 1):
-                message = f"**[{i}/{len(papers)}]**\n{paper.format_discord_message()}"
+                message = f"**[{i}/{len(papers)}]**\n{paper.format_discord_message()}\n{'-' * 50}"
                 await thread.send(message)
 
         except Exception as e:

--- a/src/thesisherald/bot.py
+++ b/src/thesisherald/bot.py
@@ -136,10 +136,20 @@ def create_bot(config: Config) -> ThesisHeraldBot:
                 )
                 return
 
-            # Send initial message and create thread
-            initial_message = await interaction.followup.send(
-                f"📚 Found {len(papers)} papers in '{category}':",
-                wait=True
+            # Send initial response
+            await interaction.followup.send(
+                f"📚 Found {len(papers)} papers in '{category}':"
+            )
+
+            # Get channel and send message to create thread from
+            channel = interaction.channel
+            if not channel or not isinstance(channel, discord.TextChannel):
+                await interaction.followup.send("❌ This command must be used in a text channel.")
+                return
+
+            # Create thread from a message in the channel
+            initial_message = await channel.send(
+                f"Search results for **{category}**:"
             )
             thread = await initial_message.create_thread(
                 name=f"Search: {category} ({len(papers)} papers)",
@@ -193,10 +203,20 @@ def create_bot(config: Config) -> ThesisHeraldBot:
                 )
                 return
 
-            # Send initial message and create thread
-            initial_message = await interaction.followup.send(
-                f"📚 Found {len(papers)} papers for keywords '{keywords}':",
-                wait=True
+            # Send initial response
+            await interaction.followup.send(
+                f"📚 Found {len(papers)} papers for keywords '{keywords}':"
+            )
+
+            # Get channel and send message to create thread from
+            channel = interaction.channel
+            if not channel or not isinstance(channel, discord.TextChannel):
+                await interaction.followup.send("❌ This command must be used in a text channel.")
+                return
+
+            # Create thread from a message in the channel
+            initial_message = await channel.send(
+                f"Search results for keywords: **{keywords}**"
             )
             thread = await initial_message.create_thread(
                 name=f"Keywords: {keywords[:80]} ({len(papers)} papers)",

--- a/src/thesisherald/bot.py
+++ b/src/thesisherald/bot.py
@@ -1,6 +1,7 @@
 """Discord bot implementation for ThesisHerald."""
 
 import logging
+from datetime import datetime
 from typing import Any
 
 import arxiv
@@ -68,7 +69,7 @@ class ThesisHeraldBot(commands.Bot):
     async def send_papers_to_channel(
         self, channel_id: int, papers: list[Any]
     ) -> None:
-        """Send paper notifications to a Discord channel."""
+        """Send paper notifications to a Discord channel in a thread."""
         channel = self.get_channel(channel_id)
         if not channel or not isinstance(channel, discord.TextChannel):
             logger.error(f"Channel {channel_id} not found or not a text channel")
@@ -78,16 +79,22 @@ class ThesisHeraldBot(commands.Bot):
             await channel.send("No new papers found today.")
             return
 
-        # Send header message
-        await channel.send(
-            f"📚 **Daily Paper Update** - Found {len(papers)} new papers:\n"
+        # Send header message and create thread
+        today = datetime.now().strftime("%Y-%m-%d")
+
+        header_message = await channel.send(
+            f"📚 **Daily Paper Update** - Found {len(papers)} new papers:"
+        )
+        thread = await header_message.create_thread(
+            name=f"Daily Papers: {today} ({len(papers)} papers)",
+            auto_archive_duration=1440  # 24 hours
         )
 
-        # Send each paper as a separate message to avoid Discord's character limit
+        # Send each paper to the thread
         for i, paper in enumerate(papers, 1):
             try:
                 message = f"**[{i}/{len(papers)}]**\n{paper.format_discord_message()}"
-                await channel.send(message)
+                await thread.send(message)
             except discord.HTTPException as e:
                 logger.error(f"Failed to send paper {paper.arxiv_id}: {e}")
 
@@ -129,13 +136,20 @@ def create_bot(config: Config) -> ThesisHeraldBot:
                 )
                 return
 
-            await interaction.followup.send(
-                f"📚 Found {len(papers)} papers in '{category}':"
+            # Send initial message and create thread
+            initial_message = await interaction.followup.send(
+                f"📚 Found {len(papers)} papers in '{category}':",
+                wait=True
+            )
+            thread = await initial_message.create_thread(
+                name=f"Search: {category} ({len(papers)} papers)",
+                auto_archive_duration=1440  # 24 hours
             )
 
+            # Send all papers in the thread
             for i, paper in enumerate(papers, 1):
                 message = f"**[{i}/{len(papers)}]**\n{paper.format_discord_message()}"
-                await interaction.followup.send(message)
+                await thread.send(message)
 
         except Exception as e:
             logger.exception("Error in search command")
@@ -179,13 +193,20 @@ def create_bot(config: Config) -> ThesisHeraldBot:
                 )
                 return
 
-            await interaction.followup.send(
-                f"📚 Found {len(papers)} papers for keywords '{keywords}':"
+            # Send initial message and create thread
+            initial_message = await interaction.followup.send(
+                f"📚 Found {len(papers)} papers for keywords '{keywords}':",
+                wait=True
+            )
+            thread = await initial_message.create_thread(
+                name=f"Keywords: {keywords[:80]} ({len(papers)} papers)",
+                auto_archive_duration=1440  # 24 hours
             )
 
+            # Send all papers in the thread
             for i, paper in enumerate(papers, 1):
                 message = f"**[{i}/{len(papers)}]**\n{paper.format_discord_message()}"
-                await interaction.followup.send(message)
+                await thread.send(message)
 
         except Exception as e:
             logger.exception("Error in keywords command")


### PR DESCRIPTION
## Summary
- Implements thread creation for all search commands to improve UX
- Keeps main channel clean by grouping search results in dedicated threads
- Makes it easier to track and reference specific searches
- Adds separator lines between papers for better readability

## Changes
### Commands Updated
- **`/search`**: Creates thread named `"Search: {category} ({count} papers)"`
- **`/keywords`**: Creates thread named `"Keywords: {keywords} ({count} papers)"`
- **`/daily`**: Creates thread named `"Daily Papers: {date} ({count} papers)"`

### Implementation Details
- [bot.py](src/thesisherald/bot.py):
  - Modified `/search` command to create threads using `channel.send()` + `create_thread()`
  - Modified `/keywords` command to create threads using `channel.send()` + `create_thread()`
  - Modified `send_papers_to_channel()` method to create threads for daily notifications
  - Added datetime import for date formatting
  - Added channel type validation to ensure TextChannel
  - Added separator lines (50 dashes) between each paper for readability
  - Thread auto-archive duration set to 1440 minutes (24 hours)

### Technical Fix
Fixed `ValueError: This message does not have guild info attached` by using `interaction.channel.send()` instead of `interaction.followup.send()` to create the message that threads are created from.

## User Experience
### Before
- Each paper result sent as separate message in main channel
- 10 papers = 11 messages (1 summary + 10 papers)
- Multiple searches = cluttered channel
- No visual separation between papers

### After
- Initial response via `interaction.followup.send()`
- Thread created from `channel.send()` message
- All papers sent within the thread with separator lines
- Main channel shows only 2 messages per search (1 followup + 1 thread starter)
- Clear visual separation between papers using dashed lines

## Example Output
```
Main Channel:
  [Bot] 📚 Found 5 papers in 'cs.AI':
  [Bot] Search results for cs.AI:
    └─ Thread: "Search: cs.AI (5 papers)"

Inside Thread:
  **[1/5]**
  **Paper Title...**
  **Authors:** ...
  ...
  --------------------------------------------------
  **[2/5]**
  **Paper Title...**
  ...
```

## Test Results
- [x] Verify linting with ruff ✅
- [x] Verify type checking with mypy ✅
- [x] Manual test: `/search cs.AI` creates thread with results ✅
- [x] Manual test: `/keywords machine learning` creates thread with results ✅
- [x] Manual test: Guild info error resolved ✅
- [x] Manual test: Separator lines improve readability ✅

## Notes
- Thread name for keywords limited to 80 characters to comply with Discord limits
- Initial followup message confirms search to user
- Separate channel message creates the thread to ensure guild info is present
- Separator lines (50 dashes) added between papers for visual clarity

Fixes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)