### PR TITLE
feat: Add optional abstract translation with full text display

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,3 +14,7 @@ ARXIV_SORT_ORDER=descending
 ANTHROPIC_API_KEY=your_anthropic_api_key_here
 LLM_MODEL=claude-3-5-sonnet-20241022
 LLM_MAX_TOKENS=4096
+
+# Translation Configuration
+ENABLE_TRANSLATION=false
+TRANSLATION_TARGET_LANG=ja

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "python-dotenv>=1.0.0",
     "anthropic>=0.18.0",
     "httpx>=0.27.0",
+    "deep-translator>=1.11.4",
 ]
 readme = "README.md"
 requires-python = ">= 3.11"

--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -29,6 +29,8 @@ attrs==25.3.0
     # via aiohttp
 audioop-lts==0.2.2
     # via discord-py
+beautifulsoup4==4.14.2
+    # via deep-translator
 certifi==2025.10.5
     # via httpcore
     # via httpx
@@ -37,6 +39,8 @@ charset-normalizer==3.4.3
     # via requests
 coverage==7.10.7
     # via pytest-cov
+deep-translator==1.11.4
+    # via thesisherald
 discord-py==2.6.3
     # via thesisherald
 distro==1.9.0
@@ -95,6 +99,7 @@ python-dotenv==1.1.1
     # via thesisherald
 requests==2.32.5
     # via arxiv
+    # via deep-translator
 ruff==0.13.3
 schedule==1.2.2
     # via thesisherald
@@ -103,8 +108,11 @@ sgmllib3k==1.0.0
 sniffio==1.3.1
     # via anthropic
     # via anyio
+soupsieve==2.8
+    # via beautifulsoup4
 typing-extensions==4.15.0
     # via anthropic
+    # via beautifulsoup4
     # via mypy
     # via pydantic
     # via pydantic-core

--- a/requirements.lock
+++ b/requirements.lock
@@ -29,12 +29,16 @@ attrs==25.3.0
     # via aiohttp
 audioop-lts==0.2.2
     # via discord-py
+beautifulsoup4==4.14.2
+    # via deep-translator
 certifi==2025.10.5
     # via httpcore
     # via httpx
     # via requests
 charset-normalizer==3.4.3
     # via requests
+deep-translator==1.11.4
+    # via thesisherald
 discord-py==2.6.3
     # via thesisherald
 distro==1.9.0
@@ -74,6 +78,7 @@ python-dotenv==1.1.1
     # via thesisherald
 requests==2.32.5
     # via arxiv
+    # via deep-translator
 schedule==1.2.2
     # via thesisherald
 sgmllib3k==1.0.0
@@ -81,8 +86,11 @@ sgmllib3k==1.0.0
 sniffio==1.3.1
     # via anthropic
     # via anyio
+soupsieve==2.8
+    # via beautifulsoup4
 typing-extensions==4.15.0
     # via anthropic
+    # via beautifulsoup4
     # via pydantic
     # via pydantic-core
     # via typing-inspection

--- a/src/thesisherald/bot.py
+++ b/src/thesisherald/bot.py
@@ -16,6 +16,42 @@ from thesisherald.llm_client import LLMClient
 logger = logging.getLogger(__name__)
 
 
+async def send_long_message(
+    channel: discord.abc.Messageable, content: str, max_length: int = 2000
+) -> None:
+    """Send a message, splitting it if it exceeds Discord's character limit.
+
+    Args:
+        channel: The channel or thread to send to
+        content: The message content
+        max_length: Maximum length per message (Discord limit is 2000)
+    """
+    if len(content) <= max_length:
+        await channel.send(content)
+        return
+
+    # Split by lines to avoid breaking in the middle of content
+    lines = content.split("\n")
+    current_chunk = ""
+
+    for line in lines:
+        # If adding this line would exceed the limit, send current chunk
+        if len(current_chunk) + len(line) + 1 > max_length:
+            if current_chunk:
+                await channel.send(current_chunk)
+                current_chunk = line + "\n"
+            else:
+                # Single line is too long, need to split it
+                for i in range(0, len(line), max_length):
+                    await channel.send(line[i : i + max_length])
+        else:
+            current_chunk += line + "\n"
+
+    # Send remaining content
+    if current_chunk:
+        await channel.send(current_chunk.rstrip())
+
+
 class ThesisHeraldBot(commands.Bot):
     """Discord bot for research paper notifications and searches."""
 
@@ -98,7 +134,7 @@ class ThesisHeraldBot(commands.Bot):
                     target_lang=self.config.translation.target_language,
                 )
                 message = f"**[{i}/{len(papers)}]**\n{formatted}\n{'-' * 50}"
-                await thread.send(message)
+                await send_long_message(thread, message)
             except discord.HTTPException as e:
                 logger.error(f"Failed to send paper {paper.arxiv_id}: {e}")
 
@@ -167,7 +203,7 @@ def create_bot(config: Config) -> ThesisHeraldBot:
                     target_lang=bot.config.translation.target_language,
                 )
                 message = f"**[{i}/{len(papers)}]**\n{formatted}\n{'-' * 50}"
-                await thread.send(message)
+                await send_long_message(thread, message)
 
         except Exception as e:
             logger.exception("Error in search command")
@@ -238,7 +274,7 @@ def create_bot(config: Config) -> ThesisHeraldBot:
                     target_lang=bot.config.translation.target_language,
                 )
                 message = f"**[{i}/{len(papers)}]**\n{formatted}\n{'-' * 50}"
-                await thread.send(message)
+                await send_long_message(thread, message)
 
         except Exception as e:
             logger.exception("Error in keywords command")

--- a/src/thesisherald/bot.py
+++ b/src/thesisherald/bot.py
@@ -93,7 +93,11 @@ class ThesisHeraldBot(commands.Bot):
         # Send each paper to the thread
         for i, paper in enumerate(papers, 1):
             try:
-                message = f"**[{i}/{len(papers)}]**\n{paper.format_discord_message()}\n{'-' * 50}"
+                formatted = paper.format_discord_message(
+                    translate=self.config.translation.enabled,
+                    target_lang=self.config.translation.target_language,
+                )
+                message = f"**[{i}/{len(papers)}]**\n{formatted}\n{'-' * 50}"
                 await thread.send(message)
             except discord.HTTPException as e:
                 logger.error(f"Failed to send paper {paper.arxiv_id}: {e}")
@@ -158,7 +162,11 @@ def create_bot(config: Config) -> ThesisHeraldBot:
 
             # Send all papers in the thread
             for i, paper in enumerate(papers, 1):
-                message = f"**[{i}/{len(papers)}]**\n{paper.format_discord_message()}\n{'-' * 50}"
+                formatted = paper.format_discord_message(
+                    translate=bot.config.translation.enabled,
+                    target_lang=bot.config.translation.target_language,
+                )
+                message = f"**[{i}/{len(papers)}]**\n{formatted}\n{'-' * 50}"
                 await thread.send(message)
 
         except Exception as e:
@@ -225,7 +233,11 @@ def create_bot(config: Config) -> ThesisHeraldBot:
 
             # Send all papers in the thread
             for i, paper in enumerate(papers, 1):
-                message = f"**[{i}/{len(papers)}]**\n{paper.format_discord_message()}\n{'-' * 50}"
+                formatted = paper.format_discord_message(
+                    translate=bot.config.translation.enabled,
+                    target_lang=bot.config.translation.target_language,
+                )
+                message = f"**[{i}/{len(papers)}]**\n{formatted}\n{'-' * 50}"
                 await thread.send(message)
 
         except Exception as e:

--- a/src/thesisherald/config.py
+++ b/src/thesisherald/config.py
@@ -95,12 +95,34 @@ class LLMConfig:
 
 
 @dataclass
+class TranslationConfig:
+    """Configuration for abstract translation."""
+
+    enabled: bool
+    target_language: str
+
+    @classmethod
+    def from_env(cls) -> "TranslationConfig":
+        """Load configuration from environment variables."""
+        enabled_str = os.getenv("ENABLE_TRANSLATION", "false").lower()
+        enabled = enabled_str in ("true", "1", "yes")
+
+        target_language = os.getenv("TRANSLATION_TARGET_LANG", "ja")
+
+        return cls(
+            enabled=enabled,
+            target_language=target_language,
+        )
+
+
+@dataclass
 class Config:
     """Main configuration container."""
 
     bot: BotConfig
     arxiv: ArxivConfig
     llm: LLMConfig
+    translation: TranslationConfig
 
     @classmethod
     def load(cls) -> "Config":
@@ -109,4 +131,5 @@ class Config:
             bot=BotConfig.from_env(),
             arxiv=ArxivConfig.from_env(),
             llm=LLMConfig.from_env(),
+            translation=TranslationConfig.from_env(),
         )


### PR DESCRIPTION
## Summary
- Adds configurable abstract translation feature using `deep-translator`
- Removes 300-character truncation and displays full abstracts
- Handles long messages exceeding Discord's 2000 character limit
- Translation is optional and configurable via environment variables

## Changes

### Core Implementation
- **[arxiv_client.py](src/thesisherald/arxiv_client.py)**:
  - Integrated `deep-translator` library for Google Translate support
  - Modified `Paper.format_discord_message()` to accept translation parameters
  - Removed 300-character abstract truncation
  - Display full abstract with optional translation appended
  - Language-specific labels for translations (要約 for Japanese, etc.)
  - Graceful error handling when translation fails

- **[config.py](src/thesisherald/config.py)**:
  - Added `TranslationConfig` class
  - Environment variables:
    - `ENABLE_TRANSLATION`: Enable/disable translation (default: false)
    - `TRANSLATION_TARGET_LANG`: Target language code (default: ja)

- **[bot.py](src/thesisherald/bot.py)**:
  - Added `send_long_message()` helper to handle messages > 2000 characters
  - Updated all commands to pass translation config to formatter
  - Intelligently splits long messages at line boundaries

### Configuration
- **[.env.example](.env.example)**:
  - Added translation configuration examples

### Dependencies
- **[pyproject.toml](pyproject.toml)**:
  - Added `deep-translator>=1.11.4` dependency

## Output Format

### Without Translation (ENABLE_TRANSLATION=false)
```
**Paper Title**
**Authors:** Author 1, Author 2
**Published:** 2024-01-01
**Categories:** cs.AI, cs.LG
**arXiv ID:** 2401.00001
**PDF:** https://arxiv.org/pdf/2401.00001

**Abstract:**
[Full abstract text without truncation]
--------------------------------------------------
```

### With Translation (ENABLE_TRANSLATION=true, TRANSLATION_TARGET_LANG=ja)
```
**Paper Title**
**Authors:** Author 1, Author 2
**Published:** 2024-01-01
**Categories:** cs.AI, cs.LG
**arXiv ID:** 2401.00001
**PDF:** https://arxiv.org/pdf/2401.00001

**Abstract:**
[Full English abstract]

**要約:**
[Japanese translation]
--------------------------------------------------
```

## Supported Languages
The feature supports any language code from ISO 639-1 that Google Translate supports:
- **ja** (Japanese): 要約
- **ko** (Korean): 요약
- **zh-CN**, **zh-TW** (Chinese): 摘要
- **es** (Spanish): Resumen
- **fr** (French): Résumé
- **de** (German): Zusammenfassung
- And many more...

## Technical Details

### Message Splitting
Messages exceeding Discord's 2000-character limit are automatically split:
1. Splits at line boundaries to preserve formatting
2. Handles single lines longer than 2000 characters
3. Maintains readability across multiple messages

### Error Handling
- Translation failures are logged but don't break the display
- Original English abstract is always shown
- Network errors during translation are caught gracefully

### Configuration
Add to your `.env` file:
```env
ENABLE_TRANSLATION=true
TRANSLATION_TARGET_LANG=ja
```

## Test Results
- [x] Verify linting with ruff ✅
- [x] Verify type checking with mypy ✅
- [x] Manual test: Translation works with ENABLE_TRANSLATION=true ✅
- [x] Manual test: Full abstract displays without truncation ✅
- [x] Manual test: Long messages split correctly ✅
- [x] Manual test: Translation disabled works (ENABLE_TRANSLATION=false) ✅

## Benefits
1. **Improved Accessibility**: Non-English speakers can read abstracts in their native language
2. **Better Context**: Full abstracts provide complete information
3. **Flexibility**: Optional feature that doesn't affect users who don't need it
4. **Reliability**: Graceful fallback when translation fails
5. **Message Handling**: Automatic splitting prevents Discord API errors

## Migration Guide
No breaking changes. Translation is disabled by default. To enable:
1. Set `ENABLE_TRANSLATION=true` in `.env`
2. Set `TRANSLATION_TARGET_LANG` to your preferred language code
3. Restart the bot

Fixes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)